### PR TITLE
Fix nil value error.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -20,7 +20,8 @@ local capi         = {
 
 
 -- Configuration. This can be overridden.
-local cyclefocus = {
+local cyclefocus
+cyclefocus = {
     -- Should clients be raised during cycling? (overrides focus_clients)
     raise_clients = true,
     -- Should clients be focused during cycling? (overridden by raise_clients)


### PR DESCRIPTION
The 'cyclefocus' variable was referred to at definition time. This
caused the variable to be always nil. Defining the variable before
assigning fixes this.

Fixes #3
