### PR TITLE
Add an option to display the switcher in the center of the screen

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -52,6 +52,9 @@ cyclefocus = {
     -- but can be disabled if you do not use sloppy focus.
     move_mouse_pointer = true,
 
+    -- Display the switcher in the center of the screen (right-aligned by default).
+    centered = false,
+
     -- How many entries should get displayed before and after the current one?
     display_next_count = 3,
     display_prev_count = 3,
@@ -1057,11 +1060,19 @@ cyclefocus.cycle = function(startdirection_or_args, args)
             wbox_screen = initial_screen
             local wa = screen[wbox_screen].workarea
             local w = math.ceil(wa.width * 0.618)
-            wbox:geometry({
-                -- right-align.
-                x = math.ceil(wa.x + wa.width - w),
-                width = w,
-            })
+            if args.centered then
+                wbox:geometry({
+                    -- position in center.
+                    x = wa.x + floor(wa.width/2 - w/2),
+                    width = w,
+                })
+            else
+                wbox:geometry({
+                    -- right-align.
+                    x = math.ceil(wa.x + wa.width - w),
+                    width = w,
+                })
+            end
         end
         local wbox_height = 0
 


### PR DESCRIPTION
Hello! This is more or less a follow-up on #23, but instead provides an option to set the position to center, while leaving the default right-alignment untouched.